### PR TITLE
Remove Optional typing for arrays.

### DIFF
--- a/fhir_py_types/ast.py
+++ b/fhir_py_types/ast.py
@@ -49,11 +49,8 @@ def make_type_annotation(
 def make_default_initializer(identifier: str, type_: StructurePropertyType):
     default_value = ast.Constant(None)
     keywords: List[ast.keyword] = []
-    if type_.isarray:
-        if not type_.required:
-            keywords.append(ast.keyword(arg="default", value=ast.Ellipsis()))
-        else:
-            keywords.append(ast.keyword(arg="default_factory", value=ast.Name("list")))
+    if type_.isarray and not type_.required:
+        keywords.append(ast.keyword(arg="default_factory", value=ast.Name("list")))
     else:
         if type_.required:
             default_value = ast.Ellipsis()


### PR DESCRIPTION
Optional typing for an array can be annoying because it forces you to check for None each time you want to iterate over a array.
A better solution might be (which I implemented in this pull request):
- Remove the Optional[] typing for all arrays (by which I mean elements with max > 1)
- Use `Field(default=...)` for required elements
- Use `Field(default_factory=list)` for optional array elements
- use `Field(default=None)` for optional (non-array) elements 

This makes it more convenient to iterate over array elements: 

```python
my_bundle = Bundle.parse_file("my_bundle.json")
assert my_bundle.entry is not None, "No entries in this bundle"
for entry in my_bundle_entry:
    pass # do stuff

```
becomes

```python
my_bundle = Bundle.parse_file("my_bundle.json")
for entry in my_bundle_entry: # entry is always a list
    pass # do stuff

```
Note that for required elements the default=... will validate that a non-empty list is passed when parsing.
More info on this https://docs.pydantic.dev/latest/usage/models/#required-optional-fields