### PR TITLE
Allow for custom Pydantic BaseModel

### DIFF
--- a/fhir_py_types/cli.py
+++ b/fhir_py_types/cli.py
@@ -45,7 +45,7 @@ def main() -> None:
             [
                 "from typing import List as List_, Optional as Optional_, Literal as Literal_, Annotated as Annotated_\n",
                 "from datetime import time, date, datetime\n",
-                "from %s import %s as BaseModel\n" % tuple(args.base_model.rsplit(".", 1))
+                "from %s import %s as BaseModel\n" % tuple(args.base_model.rsplit(".", 1)),
                 "from pydantic import Field, Extra\n",
                 "\n\n",
                 "\n\n\n".join(

--- a/fhir_py_types/cli.py
+++ b/fhir_py_types/cli.py
@@ -27,6 +27,13 @@ def main() -> None:
         required=True,
         help="File path to write generated Python typed data models to",
     )
+    argparser.add_argument(
+        "--base-model",
+        default="pydantic.BaseModel",
+        required=True,
+        help="Python path to the Base Model class to use as the base class for generated models",
+    )
+    
     args = argparser.parse_args()
 
     ast_ = itertools.chain.from_iterable(
@@ -38,7 +45,8 @@ def main() -> None:
             [
                 "from typing import List as List_, Optional as Optional_, Literal as Literal_, Annotated as Annotated_\n",
                 "from datetime import time, date, datetime\n",
-                "from pydantic import BaseModel, Field, Extra\n",
+                "from %s import %s as BaseModel\n" % tuple(args.base_model.rsplit(".", 1))
+                "from pydantic import Field, Extra\n",
                 "\n\n",
                 "\n\n\n".join(
                     ast.unparse(ast.fix_missing_locations(tree)) for tree in ast_


### PR DESCRIPTION
**What?**

I would like add an argument to the CLI to customize the BaseModel that is used in the code generation. 

**Why?**

This would allow me to add custom features to the models like an improved  __repr__, and automatic exclusion of empty (None or []) elements when serializing to dict or json. Maybe also some smart behavior with extensions

An example of a custom BaseModel

```python
from typing import TYPE_CHECKING, Sequence, Tuple, Optional, Any, Union, AbstractSet, Mapping
from pydantic import BaseModel as PydanticBaseModel
from pydantic.utils import sequence_like

if TYPE_CHECKING:
    ReprArgs = Sequence[Tuple[Optional[str], Any]]
    AbstractSetIntStr = AbstractSet[Union[int, str]]
    MappingIntStrAny = Mapping[Union[int, str], Any]

def _is_not_empty(value: Any) -> bool:
    try:
        return len(value) > 0
    except TypeError:
        return value is not None


class BaseModel(PydanticBaseModel):
    def __repr_args__(self) -> 'ReprArgs':
        return [
            (k, v)
            for k, v in super().__repr_args__() if (k not in self.__fields__ or self.__fields__[k].field_info.extra.get("summary", True)) and _is_not_empty(v)
        ]

    @classmethod
    def _get_value(
        cls,
        v: Any,
        to_dict: bool,
        by_alias: bool,
        include: Optional[Union['AbstractSetIntStr', 'MappingIntStrAny']],
        exclude: Optional[Union['AbstractSetIntStr', 'MappingIntStrAny']],
        exclude_unset: bool,
        exclude_defaults: bool,
        exclude_none: bool,
        **kwds: Any,
    ) -> Any:
        if sequence_like(v) and exclude_none and len(v) == 0:
            return None
        else:
            return super()._get_value(v=v, to_dict=to_dict,by_alias=by_alias,include=include,exclude=exclude,exclude_unset=exclude_unset,exclude_defaults=exclude_defaults,exclude_none=exclude_none, **kwds)
  ```





