### PR TITLE
AnyResources is defined multiple times.

### DIFF
--- a/fhir_py_types/cli.py
+++ b/fhir_py_types/cli.py
@@ -29,9 +29,8 @@ def main() -> None:
     )
     args = argparser.parse_args()
 
-    ast_ = itertools.chain.from_iterable(
-        build_ast(load_from_bundle(bundle)) for bundle in args.from_bundles
-    )
+    structure_definitions = itertools.chain.from_iterable(load_from_bundle(bundle) for bundle in args.from_bundles)
+    ast_ = build_ast(structure_definitions)
 
     with open(os.path.abspath(args.outfile), "w") as resource_file:
         resource_file.writelines(


### PR DESCRIPTION
When using the typegen with multiple `--from-bundles`, you end up with multiple definitions for `AnyResource`. 
The reason for this is that the `build_ast` function is executed for each bundle. See [cli.py#L32](https://github.com/beda-software/fhir-py-types/blob/main/fhir_py_types/cli.py#L32).
I think it would be better to chain all StructureDefinitions first and then call `build_ast` only a single time.