### PR TITLE
Add extensions for primitive types #6

### DIFF
--- a/fhir_py_types/__init__.py
+++ b/fhir_py_types/__init__.py
@@ -46,3 +46,8 @@ class StructureDefinition:
 
 def is_polymorphic(definition: StructureDefinition) -> bool:
     return len(definition.type) > 1
+
+
+def is_primitive_type(property_type: StructurePropertyType) -> bool:
+    # All primitive types starts with lowercased letters
+    return property_type.code[0].islower()

--- a/fhir_py_types/ast.py
+++ b/fhir_py_types/ast.py
@@ -116,7 +116,10 @@ def zip_identifier_type(
 
     for t in [remap_type(definition, t) for t in definition.type]:
         result.append((format_identifier(definition, identifier, t), t))
-        if is_primitive_type(t):
+        if (
+            definition.kind != StructureDefinitionKind.PRIMITIVE
+            and is_primitive_type(t)
+        ):
             result.append(
                 (
                     f"_{format_identifier(definition, identifier, t)}",

--- a/fhir_py_types/ast.py
+++ b/fhir_py_types/ast.py
@@ -162,7 +162,7 @@ def type_annotate(
             ),
             ast.Expr(value=ast.Constant(definition.docstring)),
         ]
-        for (identifier_, type_) in list(zip_identifier_type(definition, identifier))
+        for (identifier_, type_) in zip_identifier_type(definition, identifier)
     )
 
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -71,6 +71,16 @@ def test_generates_class_for_flat_definition() -> None:
                         simple=1,
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
+                    ast.AnnAssign(
+                        target=ast.Name(id="_property1"),
+                        annotation=ast.Subscript(
+                            value=ast.Name(id="Optional_"),
+                            slice=ast.Constant("Element"),
+                        ),
+                        value=ast.Constant(None),
+                        simple=1,
+                    ),
+                    ast.Expr(value=ast.Constant(value="test resource property 1")),
                 ],
                 decorator_list=[],
                 type_params=[],
@@ -92,10 +102,10 @@ def test_generates_class_for_flat_definition() -> None:
         (
             [
                 StructureDefinition(
-                    id="TestResource",
-                    docstring="test resource description",
+                    id="date",
+                    docstring="date description",
                     type=[
-                        StructurePropertyType(code="str", required=True, isarray=False)
+                        StructurePropertyType(code="date", required=True, isarray=False)
                     ],
                     elements={},
                     kind=StructureDefinitionKind.PRIMITIVE,
@@ -103,10 +113,10 @@ def test_generates_class_for_flat_definition() -> None:
             ],
             [
                 ast.Assign(
-                    targets=[ast.Name("TestResource")],
-                    value=ast.Name("str"),
+                    targets=[ast.Name("date")],
+                    value=ast.Name("date"),
                 ),
-                ast.Expr(value=ast.Constant("test resource description")),
+                ast.Expr(value=ast.Constant("date description")),
             ],
         ),
     ],
@@ -166,6 +176,18 @@ def test_generates_multiple_classes_for_compound_definition() -> None:
                         target=ast.Name(id="property1"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"), slice=ast.Constant("str")
+                        ),
+                        simple=1,
+                        value=ast.Constant(None),
+                    ),
+                    ast.Expr(
+                        value=ast.Constant(value="nested test resource property 1")
+                    ),
+                    ast.AnnAssign(
+                        target=ast.Name(id="_property1"),
+                        annotation=ast.Subscript(
+                            value=ast.Name(id="Optional_"),
+                            slice=ast.Constant("Element"),
                         ),
                         simple=1,
                         value=ast.Constant(None),
@@ -314,6 +336,24 @@ def test_generates_annotations_according_to_structure_type(
                         else None,
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
+                    ast.AnnAssign(
+                        target=ast.Name(id="_property1"),
+                        annotation=ast.Subscript(
+                            value=ast.Name(id="Optional_"),
+                            slice=ast.Subscript(
+                                value=ast.Name(id="List_"),
+                                slice=ast.Constant("Element"),
+                            ),
+                        )
+                        if isarray
+                        else ast.Subscript(
+                            value=ast.Name(id="Optional_"),
+                            slice=ast.Constant("Element"),
+                        ),
+                        simple=1,
+                        value=ast.Constant(None),
+                    ),
+                    ast.Expr(value=ast.Constant(value="test resource property 1")),
                 ],
                 decorator_list=[],
                 type_params=[],
@@ -329,7 +369,7 @@ def test_generates_annotations_according_to_structure_type(
     )
 
 
-def test_unrolls_required_polymorphic_into_class_uion() -> None:
+def test_unrolls_required_polymorphic_into_class_union() -> None:
     assert_eq(
         [
             StructureDefinition(
@@ -386,10 +426,32 @@ def test_unrolls_required_polymorphic_into_class_uion() -> None:
                     ),
                     ast.Expr(value=ast.Constant(value="monotype property definition")),
                     ast.AnnAssign(
+                        target=ast.Name(id="_monotype"),
+                        annotation=ast.Subscript(
+                            value=ast.Name(id="Optional_"),
+                            slice=ast.Constant("Element"),
+                        ),
+                        simple=1,
+                        value=ast.Constant(None),
+                    ),
+                    ast.Expr(value=ast.Constant(value="monotype property definition")),
+                    ast.AnnAssign(
                         target=ast.Name(id="valueBoolean"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("boolean"),
+                        ),
+                        simple=1,
+                        value=ast.Constant(None),
+                    ),
+                    ast.Expr(
+                        value=ast.Constant(value="polymorphic property definition")
+                    ),
+                    ast.AnnAssign(
+                        target=ast.Name(id="_valueBoolean"),
+                        annotation=ast.Subscript(
+                            value=ast.Name(id="Optional_"),
+                            slice=ast.Constant("Element"),
                         ),
                         simple=1,
                         value=ast.Constant(None),


### PR DESCRIPTION
It generates _property: Optional_['Element'] for all primitives including union types (_valueBoolean). And the edge case is also covered for _given: Optional_[List_[Element]] when primitive is repeatable.