### PR TITLE
Use underscore suffix instead of prefix for primitive #6

### DIFF
--- a/fhir_py_types/__init__.py
+++ b/fhir_py_types/__init__.py
@@ -33,6 +33,7 @@ class StructurePropertyType:
     isarray: bool = False
     literal: bool = False
     target_profile: list[str] | None = None
+    alias: str | None = None
 
 
 @dataclass(frozen=True)

--- a/fhir_py_types/ast.py
+++ b/fhir_py_types/ast.py
@@ -51,7 +51,7 @@ def make_default_initializer(
 ) -> ast.expr | None:
     default: ast.expr | None = None
 
-    if keyword.iskeyword(identifier):
+    if keyword.iskeyword(identifier) or type_.alias:
         default = ast.Call(
             ast.Name("Field"),
             args=[],
@@ -61,7 +61,7 @@ def make_default_initializer(
                     if not type_.required
                     else []
                 ),
-                ast.keyword(arg="alias", value=ast.Constant(identifier)),
+                ast.keyword(arg="alias", value=ast.Constant(type_.alias or identifier)),
             ],
         )
     else:
@@ -115,19 +115,20 @@ def zip_identifier_type(
     result = []
 
     for t in [remap_type(definition, t) for t in definition.type]:
-        result.append((format_identifier(definition, identifier, t), t))
-        if (
-            definition.kind != StructureDefinitionKind.PRIMITIVE
-            and is_primitive_type(t)
+        name = format_identifier(definition, identifier, t)
+        result.append((name, t))
+        if definition.kind != StructureDefinitionKind.PRIMITIVE and is_primitive_type(
+            t
         ):
             result.append(
                 (
-                    f"_{format_identifier(definition, identifier, t)}",
+                    f"{name}_",
                     StructurePropertyType(
                         code="Element",
                         target_profile=[],
                         required=False,
                         isarray=definition.type[0].isarray,
+                        alias=f"_{name}"
                     ),
                 )
             )
@@ -198,13 +199,7 @@ def define_class_object(
                 ),
             ],
             decorator_list=[],
-            keywords=[
-                ast.keyword(
-                    arg="extra",
-                    value=ast.Attribute(value=ast.Name("Extra"), attr="forbid"),
-                ),
-                ast.keyword(arg="validate_assignment", value=ast.Constant(True)),
-            ],
+            keywords=[],
             type_params=[],
         ),
         ast.Call(

--- a/fhir_py_types/ast.py
+++ b/fhir_py_types/ast.py
@@ -122,7 +122,7 @@ def zip_identifier_type(
         ):
             result.append(
                 (
-                    f"{name}_",
+                    f"{name}__ext",
                     StructurePropertyType(
                         code="Element",
                         target_profile=[],

--- a/fhir_py_types/cli.py
+++ b/fhir_py_types/cli.py
@@ -9,6 +9,7 @@ from fhir_py_types.reader.bundle import load_from_bundle
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
 def main() -> None:
@@ -38,15 +39,13 @@ def main() -> None:
             load_from_bundle(bundle) for bundle in args.from_bundles
         )
     )
+    with open(os.path.join(dir_path, "header.py.tpl")) as header_file:
+        header_lines = header_file.readlines()
 
     with open(os.path.abspath(args.outfile), "w") as resource_file:
         resource_file.writelines(
             [
-                "from typing import List as List_, Optional as Optional_, Literal as Literal_, Annotated as Annotated_\n",
-                "from {} import {} as BaseModel\n".format(
-                    *args.base_model.rsplit(".", 1)
-                ),
-                "from pydantic import Field, Extra\n",
+                *header_lines,
                 "\n\n",
                 "\n\n\n".join(
                     ast.unparse(ast.fix_missing_locations(tree)) for tree in ast_

--- a/fhir_py_types/cli.py
+++ b/fhir_py_types/cli.py
@@ -9,7 +9,6 @@ from fhir_py_types.reader.bundle import load_from_bundle
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
-dir_path = os.path.dirname(os.path.realpath(__file__))
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -41,9 +40,6 @@ def main() -> None:
             load_from_bundle(bundle) for bundle in args.from_bundles
         )
     )
-    with open(os.path.join(dir_path, "header.py.tpl")) as header_file:
-        header_lines = header_file.readlines()
-
     with open(os.path.join(dir_path, "header.py.tpl")) as header_file:
         header_lines = header_file.readlines()
 

--- a/fhir_py_types/header.py.tpl
+++ b/fhir_py_types/header.py.tpl
@@ -7,6 +7,7 @@ class BaseModel(BaseModel_):
     class Config:
         extra = Extra.forbid
         validate_assignment = True
+        allow_population_by_field_name = True
     
     def dict(self, *args, **kwargs):
         by_alias = kwargs.pop('by_alias', True)

--- a/fhir_py_types/header.py.tpl
+++ b/fhir_py_types/header.py.tpl
@@ -1,0 +1,13 @@
+from typing import List as List_, Optional as Optional_, Literal as Literal_, Annotated as Annotated_
+from pydantic import BaseModel as BaseModel_
+from pydantic import Field, Extra
+
+
+class BaseModel(BaseModel_):
+    class Config:
+        extra = Extra.forbid
+        validate_assignment = True
+    
+    def dict(self, *args, **kwargs):
+        by_alias = kwargs.pop('by_alias', True)
+        return super().dict(*args, **kwargs, by_alias=by_alias)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -75,7 +75,7 @@ def test_generates_class_for_flat_definition() -> None:
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
                     ast.AnnAssign(
-                        target=ast.Name(id="property1_"),
+                        target=ast.Name(id="property1__ext"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
@@ -187,7 +187,7 @@ def test_generates_multiple_classes_for_compound_definition() -> None:
                         value=ast.Constant(value="nested test resource property 1")
                     ),
                     ast.AnnAssign(
-                        target=ast.Name(id="property1_"),
+                        target=ast.Name(id="property1__ext"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
@@ -340,7 +340,7 @@ def test_generates_annotations_according_to_structure_type(
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
                     ast.AnnAssign(
-                        target=ast.Name(id="property1_"),
+                        target=ast.Name(id="property1__ext"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Subscript(
@@ -429,7 +429,7 @@ def test_unrolls_required_polymorphic_into_class_union() -> None:
                     ),
                     ast.Expr(value=ast.Constant(value="monotype property definition")),
                     ast.AnnAssign(
-                        target=ast.Name(id="monotype_"),
+                        target=ast.Name(id="monotype__ext"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
@@ -451,7 +451,7 @@ def test_unrolls_required_polymorphic_into_class_union() -> None:
                         value=ast.Constant(value="polymorphic property definition")
                     ),
                     ast.AnnAssign(
-                        target=ast.Name(id="valueBoolean_"),
+                        target=ast.Name(id="valueBoolean__ext"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -10,14 +10,6 @@ from fhir_py_types import (
 )
 from fhir_py_types.ast import build_ast
 
-EXPECTED_BASE_MODEL_CONFIG = [
-    ast.keyword(
-        arg="extra",
-        value=ast.Attribute(value=ast.Name("Extra"), attr="forbid"),
-    ),
-    ast.keyword(arg="validate_assignment", value=ast.Constant(True)),
-]
-
 
 def assert_eq(
     definitions: Sequence[StructureDefinition], ast_tree: Sequence[ast.stmt | ast.expr]
@@ -26,6 +18,17 @@ def assert_eq(
     expected = [ast.dump(t) for t in ast_tree]
 
     assert generated == expected
+
+
+def build_field_with_alias(identifier: str) -> ast.Call:
+    return ast.Call(
+        func=ast.Name(id="Field"),
+        args=[],
+        keywords=[
+            ast.keyword(arg="default", value=ast.Constant(value=None)),
+            ast.keyword(arg="alias", value=ast.Constant(value=identifier)),
+        ],
+    )
 
 
 def test_generates_empty_ast_from_empty_definitions() -> None:
@@ -62,7 +65,7 @@ def test_generates_class_for_flat_definition() -> None:
             ast.ClassDef(
                 name="TestResource",
                 bases=[ast.Name(id="BaseModel")],
-                keywords=EXPECTED_BASE_MODEL_CONFIG,
+                keywords=[],
                 body=[
                     ast.Expr(value=ast.Constant(value="test resource description")),
                     ast.AnnAssign(
@@ -72,12 +75,12 @@ def test_generates_class_for_flat_definition() -> None:
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
                     ast.AnnAssign(
-                        target=ast.Name(id="_property1"),
+                        target=ast.Name(id="property1_"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
                         ),
-                        value=ast.Constant(None),
+                        value=build_field_with_alias("_property1"),
                         simple=1,
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
@@ -169,7 +172,7 @@ def test_generates_multiple_classes_for_compound_definition() -> None:
             ast.ClassDef(
                 name="NestedTestResource",
                 bases=[ast.Name(id="BaseModel")],
-                keywords=EXPECTED_BASE_MODEL_CONFIG,
+                keywords=[],
                 body=[
                     ast.Expr(value=ast.Constant(value="nested resource definition")),
                     ast.AnnAssign(
@@ -184,13 +187,13 @@ def test_generates_multiple_classes_for_compound_definition() -> None:
                         value=ast.Constant(value="nested test resource property 1")
                     ),
                     ast.AnnAssign(
-                        target=ast.Name(id="_property1"),
+                        target=ast.Name(id="property1_"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
                         ),
                         simple=1,
-                        value=ast.Constant(None),
+                        value=build_field_with_alias("_property1"),
                     ),
                     ast.Expr(
                         value=ast.Constant(value="nested test resource property 1")
@@ -202,7 +205,7 @@ def test_generates_multiple_classes_for_compound_definition() -> None:
             ast.ClassDef(
                 name="TestResource",
                 bases=[ast.Name(id="BaseModel")],
-                keywords=EXPECTED_BASE_MODEL_CONFIG,
+                keywords=[],
                 body=[
                     ast.Expr(value=ast.Constant(value="test resource description")),
                     ast.AnnAssign(
@@ -322,7 +325,7 @@ def test_generates_annotations_according_to_structure_type(
             ast.ClassDef(
                 name="TestResource",
                 bases=[ast.Name(id="BaseModel")],
-                keywords=EXPECTED_BASE_MODEL_CONFIG,
+                keywords=[],
                 body=[
                     ast.Expr(value=ast.Constant(value="test resource description")),
                     ast.AnnAssign(
@@ -337,7 +340,7 @@ def test_generates_annotations_according_to_structure_type(
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
                     ast.AnnAssign(
-                        target=ast.Name(id="_property1"),
+                        target=ast.Name(id="property1_"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Subscript(
@@ -351,7 +354,7 @@ def test_generates_annotations_according_to_structure_type(
                             slice=ast.Constant("Element"),
                         ),
                         simple=1,
-                        value=ast.Constant(None),
+                        value=build_field_with_alias("_property1"),
                     ),
                     ast.Expr(value=ast.Constant(value="test resource property 1")),
                 ],
@@ -412,7 +415,7 @@ def test_unrolls_required_polymorphic_into_class_union() -> None:
             ast.ClassDef(
                 name="TestResource",
                 bases=[ast.Name(id="BaseModel")],
-                keywords=EXPECTED_BASE_MODEL_CONFIG,
+                keywords=[],
                 body=[
                     ast.Expr(value=ast.Constant(value="test resource description")),
                     ast.AnnAssign(
@@ -426,13 +429,13 @@ def test_unrolls_required_polymorphic_into_class_union() -> None:
                     ),
                     ast.Expr(value=ast.Constant(value="monotype property definition")),
                     ast.AnnAssign(
-                        target=ast.Name(id="_monotype"),
+                        target=ast.Name(id="monotype_"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
                         ),
                         simple=1,
-                        value=ast.Constant(None),
+                        value=build_field_with_alias("_monotype"),
                     ),
                     ast.Expr(value=ast.Constant(value="monotype property definition")),
                     ast.AnnAssign(
@@ -448,13 +451,13 @@ def test_unrolls_required_polymorphic_into_class_union() -> None:
                         value=ast.Constant(value="polymorphic property definition")
                     ),
                     ast.AnnAssign(
-                        target=ast.Name(id="_valueBoolean"),
+                        target=ast.Name(id="valueBoolean_"),
                         annotation=ast.Subscript(
                             value=ast.Name(id="Optional_"),
                             slice=ast.Constant("Element"),
                         ),
                         simple=1,
-                        value=ast.Constant(None),
+                        value=build_field_with_alias("_valueBoolean"),
                     ),
                     ast.Expr(
                         value=ast.Constant(value="polymorphic property definition")


### PR DESCRIPTION
Within this PR I've changed the underscore prefix to the underscore suffix. Moreover, in the code, it was already used for keywords like for_, class_.  See my last comment #6 for details.

Also, I've overridden the base model class changing `dict()` behavior to return the alias name by default. (Closes #17)

